### PR TITLE
[Mod Integration - "Krastorio2"] [SpaceAge] - Support "Krastorio2 - Spaced Out"

### DIFF
--- a/Common-Industries/bridge1-base.lua
+++ b/Common-Industries/bridge1-base.lua
@@ -62,7 +62,7 @@ bridge.mods_list = {
   { short_name = "aaind", name = "aai-industry" },
   -- K2    https://mods.factorio.com/user/raiguard
   { short_name = "k2",    name = "Krastorio2" },
-  { short_name = "k2so",    name = "Krastorio2-spaced-out" },
+  { short_name = "k2so",  name = "Krastorio2-spaced-out" },
   -- 248k  https://mods.factorio.com/mod/248k
   { short_name = "_248k", name = "248k" },
 

--- a/Common-Industries/bridge1-base.lua
+++ b/Common-Industries/bridge1-base.lua
@@ -62,6 +62,7 @@ bridge.mods_list = {
   { short_name = "aaind", name = "aai-industry" },
   -- K2    https://mods.factorio.com/user/raiguard
   { short_name = "k2",    name = "Krastorio2" },
+  { short_name = "k2so",    name = "Krastorio2-spaced-out" },
   -- 248k  https://mods.factorio.com/mod/248k
   { short_name = "_248k", name = "248k" },
 

--- a/Common-Industries/item-age0.lua
+++ b/Common-Industries/item-age0.lua
@@ -27,6 +27,11 @@ add_item({
       prereq = "kr-stone-processing",
     },
     {
+      mod = bridge.mods.k2so,
+      name = "kr-sand",
+      prereq = "kr-stone-processing",
+    },
+    {
       mod = bridge.mods.bobores,
       name = "quartz",
       prereq = bridge.empty,

--- a/Common-Industries/item-age1.lua
+++ b/Common-Industries/item-age1.lua
@@ -32,6 +32,11 @@ add_item({
       prereq = "kr-stone-processing",
     },
     {
+      mod = bridge.mods.k2so,
+      name = "kr-glass",
+      prereq = "kr-stone-processing",
+    },
+    {
       mod = bridge.mods.ir3,
       name = "glass",
       prereq = "ir-glass-milestone",

--- a/Common-Industries/item-age2.lua
+++ b/Common-Industries/item-age2.lua
@@ -55,6 +55,11 @@ add_item({
       prereq = bridge.empty,
     },
     {
+      mod = bridge.mods.k2so,
+      name = "kr-biomass",
+      prereq = bridge.empty,
+    },
+    {
       mod = bridge.mods.se,
       name = "se-specimen",
       prereq = "se-space-genetics-laboratory",
@@ -228,6 +233,14 @@ add_item({
       },
     },
     {
+      mod = bridge.mods.k2so,
+      ingredients = {
+        {bridge.item.optic_cable, 2},
+        {"kr-quartz", 1},
+        {"advanced-circuit", 1},
+      },
+    },
+    {
       mod = bridge.mods.ir3,
       name = "helium-laser",
       prereq = "laser-2",
@@ -348,6 +361,10 @@ add_item({
     {
       mod = bridge.mods.k2,
       ingredients = {{ "steel-plate", 10 }, { "copper-plate", 4 }, { "imersite-powder", 10 }},
+    },
+    {
+      mod = bridge.mods.k2so,
+      ingredients = {{ "steel-plate", 10 }, { "copper-plate", 4 }, { "kr-imersite-powder", 10 }},
     },
     {
       mod = bridge.mods.exind,

--- a/Common-Industries/item-age3.lua
+++ b/Common-Industries/item-age3.lua
@@ -208,6 +208,15 @@ add_item({
       },
     },
     {
+      mod = bridge.mods.k2so,
+      prereq = "kr-imersium-processing",
+      ingredients = {
+        {"kr-imersium-plate", 2},
+        {"copper-cable", 10},
+        {"plastic-bar", 2},
+      },
+    },
+    {
       mod = bridge.mods.py_fus,
       name = "sc-wire",
       prereq = "magnetic-core",
@@ -342,6 +351,15 @@ add_item({
       ingredients = {
         {"low-density-structure", 10},
         {"imersium-plate", 10},
+        {"silicon", 10},
+      },
+    },
+    {
+      mod = bridge.mods.k2so,
+      prereq = "kr-imersium-processing",
+      ingredients = {
+        {"low-density-structure", 10},
+        {"kr-imersium-plate", 10},
         {"silicon", 10},
       },
     },
@@ -514,6 +532,11 @@ add_item({
       prereq = "kr-energy-control-unit",
     },
     {
+      mod = bridge.mods.k2so,
+      name = "kr-energy-control-unit",
+      prereq = "kr-energy-control-unit",
+    },
+    {
       mod = bridge.mods.se,
       prereq = bridge.item.nano_mat,
     },
@@ -635,6 +658,12 @@ add_item({
       prereq = "kr-antimatter-reactor",
     },
     {
+      mod = bridge.mods.k2so,
+      -- name = "kr-antimatter-reactor",
+      name = "kr-antimatter-reactor-equipment",
+      prereq = "kr-antimatter-reactor",
+    },
+    {
       mod = bridge.mods.bobequip,
       name = "fusion-reactor-equipment-4",
       prereq = "earnshaw-theorem",
@@ -661,6 +690,12 @@ add_item({
       mod = bridge.mods.k2,
       -- Or krastorio.recipes.changed_names["charged-antimatter-fuel-cell"] ?!
       name = "charged-antimatter-fuel-cell",
+      prereq = "kr-antimatter-reactor",
+    },
+    {
+      mod = bridge.mods.k2so,
+      -- Or krastorio.recipes.changed_names["charged-antimatter-fuel-cell"] ?!
+      name = "kr-charged-antimatter-fuel-cell",
       prereq = "kr-antimatter-reactor",
     },
     -- TODO: check out other mods!

--- a/Common-Industries/item-age4.lua
+++ b/Common-Industries/item-age4.lua
@@ -77,6 +77,17 @@ add_item({
         {bridge.item.nano_mat, 8},
       },
     },
+    {
+      mod = bridge.mods.k2so,
+      prereq = "kr-matter-processing",
+      -- name = "matter-stabilizer",
+      ingredients = {
+        {"kr-matter-stabilizer", 3},
+        {bridge.item.he_emitter, 3},
+        {bridge.item.quantum_chip, 1},
+        {bridge.item.nano_mat, 8},
+      },
+    },
   },
 })
 

--- a/Ricks-Car-Spaceship/data-final-fixes.lua
+++ b/Ricks-Car-Spaceship/data-final-fixes.lua
@@ -12,13 +12,13 @@ for _, name in pairs(wanted_categories) do
 	end
 end
 
-if not mods[shared.K2] then
+if not mods[shared.K2] and not mods[shared.K2SO] then
 	table.insert(space_cruiser_grid.equipment_categories, "armor")
 end
 
 local titan_supplier = data.raw.car[shared.space_cruiser]
 titan_supplier.energy_source.fuel_categories = {"nuclear"}
-if mods[shared.K2] then
+if mods[shared.K2] or mods[shared.K2SO] then
 	titan_supplier.energy_source.fuel_categories = {"nuclear-fuel"}
 	-- TODO: make only fusion for late-game mode/tier
   table.insert(titan_supplier.energy_source.fuel_categories, "fusion-fuel")

--- a/Ricks-Car-Spaceship/shared.lua
+++ b/Ricks-Car-Spaceship/shared.lua
@@ -8,5 +8,6 @@ shared.space_cruiser = shared.mod_prefix.."cruiser"
 shared.AIND = "aai-industry"
 shared.SE = "space-exploration"
 shared.K2 = "Krastorio2"
+shared.K2SO = "Krastorio2-spaced-out"
 
 return shared

--- a/WH40k-Titans/data-final-fixes.lua
+++ b/WH40k-Titans/data-final-fixes.lua
@@ -79,7 +79,7 @@ for _, name in pairs(wanted_categories) do
 	end
 end
 
-if not mods[shared.K2] then
+if not mods[shared.K2] and not mods[shared.K2SO] then
 	table.append(aircraft_grid.equipment_categories, "armor")
 end
 
@@ -89,7 +89,7 @@ titan_supplier.energy_source.fuel_categories = {"chemical"}
 if mods[shared.AIND] then
   table.append(titan_supplier.energy_source.fuel_categories, "processed-chemical")
 end
-if mods[shared.K2] then
+if mods[shared.K2] or mods[shared.K2SO] then
 	table.extend(titan_supplier.energy_source.fuel_categories, {
 		"vehicle-fuel", "nuclear-fuel", "fusion-fuel", "antimatter-fuel",
 	})

--- a/WH40k-Titans/prototypes/science.lua
+++ b/WH40k-Titans/prototypes/science.lua
@@ -32,7 +32,7 @@ if mods[shared.SA] then
     {type="item", name="promethium-science-pack", amount=10},
   }
 
-elseif mods[shared.SE] and mods[shared.K2] then
+elseif mods[shared.SE] and (mods[shared.K2] or mods[shared.K2SO]) then
   ingredients = {  -- 8
     {type="item", name="military-science-pack", amount=10},
     -- {type="item", name="space-science-pack", amount=10},
@@ -63,7 +63,7 @@ elseif mods[shared.SE] then
     {type="item", name="se-deep-space-science-pack-1", amount=10},
   }
 
-elseif mods[shared.K2] then
+elseif (mods[shared.K2] or mods[shared.K2SO]) then
   ingredients = {  -- 6
     {type="item", name="production-science-pack", amount=10},
     {type="item", name="utility-science-pack", amount=10},

--- a/WH40k-Titans/shared/shared-base.lua
+++ b/WH40k-Titans/shared/shared-base.lua
@@ -148,5 +148,6 @@ shared.SA   = "space-age"
 shared.AIND = "aai-industry"
 shared.SE   = "space-exploration"
 shared.K2   = "Krastorio2"
+shared.K2SO = "Krastorio2-spaced-out"
 
 return shared


### PR DESCRIPTION
Hey there!

First timer here with a potential PR to support Krastorio2 - Spaced Out, which changes some common names and items. Specifically, this merges the `Sand` and `Glass` hierarchies and entities, and should fix some of the now-prefixed names. This is a more complete set of changes than what I made locally to get support running, so it may need more tweaks, but figured I'd pass on what I found.

The main thing I'm not sure about is the mod name; `Krastorio2` vs `Krastorio2-spaced-out`. I was able to get the mod working by just making the `CommonIndustry` elements add for `kr-sand` /`kr-glass` instead, but wasn't sure if you wanted to keep support for old and new Krastorio. If the separation isn't necessary, I think we can get rid of all the `so` suffixes that differentiate the SA and non-SA variants altogether.

Thanks for the fun mod, looking forward to helping out!